### PR TITLE
update default primo instance

### DIFF
--- a/config/primo.yml
+++ b/config/primo.yml
@@ -13,7 +13,7 @@ pre_production:
   <<: *production
 
 prep:
-  <<: *test
+  <<: *production
 
 dm_production:
   <<: *test

--- a/config/primo.yml
+++ b/config/primo.yml
@@ -10,7 +10,7 @@ development:
   <<: *test
 
 pre_production:
-  <<: *test
+  <<: *production
 
 prep:
   <<: *test


### PR DESCRIPTION
Changing which endpoints the prep instances of API will hit. This is being requested to facilitate testing of the API, as testing against Primo sandbox may result in false failures if the record set changes within the limited scope of the sandbox.