### PR TITLE
fix for unseparated courses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,12 +13,12 @@ group :application do
   gem 'omniauth-oktaoauth'
 
   gem 'devise-token_authenticatable'
-  
+
   #check to see if there is a version above 2.4.0.
   # this was added to bc there is a fix in master for cyrillic characters that has not been released.
   # gem 'nori', git: 'https://github.com/savonrb/nori.git', ref: '3a9cdb63e624430b970ef48a641d8622840ebbbc'
   gem 'jquery-rails'
-  gem 'mysql2', '~> 0.4.4' #, '<= 0.3.19'
+  gem 'mysql2', '~> 0.5.3' #, '<= 0.3.19'
   # gem 'activerecord-mysql2-adapter'
   gem "faraday"
   gem "faraday_middleware"
@@ -43,10 +43,10 @@ group :application do
   gem "nori", '~> 2.5.0'
 
   gem 'addressable'
- 
+
   # Sentry.io integration
   gem "sentry-raven"
-  
+
   gem 'virtus'
   gem 'sunspot_rails', '2.3.0' # '<= 2.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.10)
+    mysql2 (0.5.3)
     net-ldap (0.16.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -362,7 +362,7 @@ DEPENDENCIES
   jquery-rails
   json_spec
   multi_xml
-  mysql2 (~> 0.4.4)
+  mysql2 (~> 0.5.3)
   net-ldap
   nori (~> 2.5.0)
   omniauth-oktaoauth

--- a/lib/csv_helper.rb
+++ b/lib/csv_helper.rb
@@ -112,6 +112,8 @@ module CSVHelper
       instructor[:term] = data_elements[:term]
       instructor[:status] = data_elements[:status]
       instructor[:section_groups] = {} if instructor[:section_groups].blank?
+
+
       if data_elements[:status] == "Primary"
         instructor[:section_groups][course_triple(data_elements).to_s] = build_instructor_section_groups(instructor, data_elements)
       end
@@ -151,7 +153,12 @@ module CSVHelper
     end
 
     def course_triple(data_elements)
-      "#{data_elements[:term]}_#{data_elements[:alpha_prefix]}_#{data_elements[:number]}"
+      triple = "#{data_elements[:term]}_#{data_elements[:alpha_prefix]}_#{data_elements[:number]}"
+      if triple === "202010_ENGL_13186"        
+        triple += "_#{data_elements[:section]}"
+      end
+
+      triple
     end
 
     def get_title(data_elements)


### PR DESCRIPTION
Problem: 

We join all the sections for a course with the same number as one course for simplicity and so that users don't have to join them themselves. 

This created a problem where this one seminar class has 2 sections from the same instructor but is actually 2 different classes.  

To fix it I was very specific and separated the classes at index time.  
My reasoning is 
1.  we have only done this 1 time in 7 years so it is not a very common case. Probably because usually, instructors do not teach 2 of the special topics seminar classes in a semester, and if they do they have not requested reserves. 
2.  I am trying to do the bare minimum in round one.  If this comes up again we will create a structure for these courses in the banner indexer and on the third time maybe make a UI or something it depends if it happens again and when. 

Threats to this:
We may get more requests for reserves because of remote classes or because of the checked-out resources project.  Which could cause this to happen more in the future.  


